### PR TITLE
Reorder conda channels to improve env solving performance

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 name: recode_rnaseq
 channels:
-  - bioconda
   - conda-forge
+  - bioconda
   - defaults
 dependencies:
   - openssl=1.1.1q


### PR DESCRIPTION
This PR reorders the conda channels listed in `environment.yml` to improve the performance of the "environment solving" step carried out by conda during package installation. See issue #7 for further details.

Closes #7.